### PR TITLE
[DEVEL-626] Convert snake to camel case

### DIFF
--- a/Sources/SwiftGenKit/Parsers/Strings/Parameter.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/Parameter.swift
@@ -35,7 +35,7 @@ extension Strings.Parameter {
             guard let range = Range(result.range(at: 1), in: string) else {
                 return nil
             }
-            return String(string[range])
+            return String(string[range]).snakeToCamelCase
         }
         
         return parameterNames.map { .init(name: $0, type: type) }
@@ -43,6 +43,8 @@ extension Strings.Parameter {
 }
 
 // MARK: - Private Helpers
+
+// MARK: Parameter Regex
 
 private extension Strings.Parameter {
     /// This regular expression is used to match named parameters embedded within double curly braces in a string.
@@ -60,4 +62,34 @@ private extension Strings.Parameter {
             fatalError("Error building the regular expression used to match the named parameter format")
         }
     }()
+}
+
+// MARK: String Helpers
+
+private extension String {
+    /// Converts a `snake_case` string to `camelCase`.
+    ///
+    /// - Note: Handles edge cases such as leading, trailing, and multiple underscores by ignoring them
+    /// and not including empty segments in the output. If the input is an empty string or consists only
+    /// of underscores, the computed property will return an empty string.
+    var snakeToCamelCase: String {
+        guard !self.isEmpty else { return "" }
+
+        let components = self.split(separator: "_")
+        
+        guard !components.isEmpty else { return "" }
+        
+        return components.enumerated().map { (index, element) in
+            let lowercased = element.lowercased()
+            if index == 0 {
+                return lowercased
+            } else {
+                return lowercased.capitalizingFirstLetter
+            }
+        }.joined()
+    }
+    
+    var capitalizingFirstLetter: String {
+        prefix(1).capitalized + dropFirst()
+    }
 }

--- a/Sources/SwiftGenKit/Parsers/Strings/Parameter.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/Parameter.swift
@@ -35,10 +35,10 @@ extension Strings.Parameter {
             guard let range = Range(result.range(at: 1), in: string) else {
                 return nil
             }
-            return String(string[range]).snakeToCamelCase
+            return String(string[range])
         }
         
-        return parameterNames.map { .init(name: $0, type: type) }
+        return parameterNames.map { .init(name: $0.snakeToCamelCase, type: type) }
     }
 }
 
@@ -64,7 +64,7 @@ private extension Strings.Parameter {
     }()
 }
 
-// MARK: String Helpers
+// MARK: String Formatting
 
 private extension String {
     /// Converts a `snake_case` string to `camelCase`.

--- a/Sources/SwiftGenKit/Parsers/Strings/Parameter.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/Parameter.swift
@@ -79,13 +79,9 @@ private extension String {
         
         guard !components.isEmpty else { return "" }
         
-        return components.enumerated().map { (index, element) in
+        return components.enumerated().map { index, element in
             let lowercased = element.lowercased()
-            if index == 0 {
-                return lowercased
-            } else {
-                return lowercased.capitalizingFirstLetter
-            }
+            return index == 0 ? lowercased : lowercased.capitalizingFirstLetter
         }.joined()
     }
     

--- a/Tests/SwiftGenKitTests/StringsDictFileParserTests.swift
+++ b/Tests/SwiftGenKitTests/StringsDictFileParserTests.swift
@@ -49,7 +49,7 @@ final class StringsDictFileParserTests: XCTestCase {
         XCTAssertEqual(firstEntryParameters.count, 1)
         XCTAssertEqual(
             firstEntryParameters,
-            [.init(name: "pot_count", type: .int)]
+            [.init(name: "potCount", type: .int)]
         )
     }
 }

--- a/Tests/SwiftGenKitTests/StringsFileParserTests.swift
+++ b/Tests/SwiftGenKitTests/StringsFileParserTests.swift
@@ -86,7 +86,7 @@ final class StringsFileParserTests: XCTestCase {
             thirdEntryParameters,
             [
                 .init(name: "name", type: .object),
-                .init(name: "message_count", type: .object)
+                .init(name: "messageCount", type: .object)
             ]
         )
     }

--- a/Tests/SwiftGenKitTests/StringsFileParserTests.swift
+++ b/Tests/SwiftGenKitTests/StringsFileParserTests.swift
@@ -47,7 +47,7 @@ final class StringsFileParserTests: XCTestCase {
             [
                 "Hello, {{name}}!",
                 "This string has no named parameters",
-                "Welcome, {{name}}! You have {{message_count}} unread messages."
+                "Welcome, {{name}}! You have {{messageCount}} unread messages."
             ]
         )
     }
@@ -86,7 +86,7 @@ final class StringsFileParserTests: XCTestCase {
             thirdEntryParameters,
             [
                 .init(name: "name", type: .object),
-                .init(name: "message_count", type: .object)
+                .init(name: "messageCount", type: .object)
             ]
         )
     }

--- a/Tests/SwiftGenKitTests/StringsFileParserTests.swift
+++ b/Tests/SwiftGenKitTests/StringsFileParserTests.swift
@@ -47,7 +47,7 @@ final class StringsFileParserTests: XCTestCase {
             [
                 "Hello, {{name}}!",
                 "This string has no named parameters",
-                "Welcome, {{name}}! You have {{messageCount}} unread messages."
+                "Welcome, {{name}}! You have {{message_count}} unread messages."
             ]
         )
     }
@@ -86,7 +86,7 @@ final class StringsFileParserTests: XCTestCase {
             thirdEntryParameters,
             [
                 .init(name: "name", type: .object),
-                .init(name: "messageCount", type: .object)
+                .init(name: "message_count", type: .object)
             ]
         )
     }

--- a/Tests/SwiftGenKitTests/StringsParameterTests.swift
+++ b/Tests/SwiftGenKitTests/StringsParameterTests.swift
@@ -27,7 +27,7 @@ final class StringsParameterTests: XCTestCase {
         )
         
         // Then
-        XCTAssertEqual(parametersNames, [.init(name: "display_name", type: .object)])
+        XCTAssertEqual(parametersNames, [.init(name: "displayName", type: .object)])
     }
     
     func test_extractParameterNames_returnsMultipleNamedParameters() {
@@ -44,7 +44,7 @@ final class StringsParameterTests: XCTestCase {
         XCTAssertEqual(
             parameterNames,
             [
-                .init(name: "apple_count", type: .object),
+                .init(name: "appleCount", type: .object),
                 .init(name: "name", type: .object)
             ]
         )
@@ -69,6 +69,7 @@ final class StringsParameterTests: XCTestCase {
             
             // Then
             XCTAssertFalse(parameterNames.isEmpty)
+            print("M:", parameterNames)
         }
     }
     
@@ -107,7 +108,7 @@ final class StringsParameterTests: XCTestCase {
         )
         
         // Then
-        XCTAssertEqual(parameterNames, [.init(name: "parameter_name", type: .object)])
+        XCTAssertEqual(parameterNames, [.init(name: "parameterName", type: .object)])
     }
     
     func test_extractParameterNames_returnsStringPlaceholderType() {
@@ -136,5 +137,34 @@ final class StringsParameterTests: XCTestCase {
         
         // Then
         XCTAssertEqual(parameterNames[0].type, placeholderType)
+    }
+    
+    func test_extractParameterNames_convertsSnakeToCamelCase() {
+        // Given
+        let strings = [
+            "{{parameter_name}}",
+            "{{this_is_a_test}}",
+            "{{}}",
+            "{{param_name_}}",
+            "{{foo__bar}}",
+            "{{_}}"
+        ]
+        
+        let expectedResults = [
+            "parameterName",
+            "thisIsATest",
+            "paramName",
+            "fooBar"
+        ]
+       
+        // When
+        let parameters = strings.flatMap {
+            Strings.Parameter.extractParameterNames(from: $0, type: .object)
+        }
+        
+        // Then
+        for (index, parameter) in parameters.enumerated() {
+            XCTAssertEqual(parameter.name, expectedResults[index])
+        }
     }
 }

--- a/Tests/SwiftGenKitTests/StringsParameterTests.swift
+++ b/Tests/SwiftGenKitTests/StringsParameterTests.swift
@@ -69,7 +69,6 @@ final class StringsParameterTests: XCTestCase {
             
             // Then
             XCTAssertFalse(parameterNames.isEmpty)
-            print("M:", parameterNames)
         }
     }
     


### PR DESCRIPTION
This PR adds the functionality to be able to convert from snake case to camel case. This is needed when we format the strings that will be used to generate the named parameters in the generated APIs.

